### PR TITLE
The configuration parameter `password` has been replaced with `API Key`

### DIFF
--- a/group-ib-threat-intelligence-attribution-feed/connector.py
+++ b/group-ib-threat-intelligence-attribution-feed/connector.py
@@ -1,7 +1,7 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2024   Fortinet Inc
+Copyright (c) 2025   Fortinet Inc
 Copyright end
 """
 

--- a/group-ib-threat-intelligence-attribution-feed/constants.py
+++ b/group-ib-threat-intelligence-attribution-feed/constants.py
@@ -1,7 +1,7 @@
 """"
 Copyright start
 MIT License
-Copyright (c) 2024   Fortinet Inc
+Copyright (c) 2025   Fortinet Inc
 Copyright end
 """
 

--- a/group-ib-threat-intelligence-attribution-feed/info.json
+++ b/group-ib-threat-intelligence-attribution-feed/info.json
@@ -6,11 +6,11 @@
   "contributor":"Naili.M",
   "cs_approved": false,
   "cs_compatible": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "category": "Investigation",
   "icon_small_name": "Group_IB_Threat_Intelligence_small.png",
   "icon_large_name": "Group_IB_Threat_Intelligence_large.png",
-  "help_online": "https://github.com/fortinet-fortisoar/connector-group-ib-threat-intelligence-attribution-feed/blob/release/1.1.0/docs/GroupIb-TIA-Feed.md",
+  "help_online": "",
   "configuration": {
     "fields": [
       {
@@ -32,13 +32,13 @@
         "description": "Username used to access the Group IB server to which you will connect and perform the automated operations."
       },
       {
-        "title": "Password",
+        "title": "API Key",
         "required": true,
         "editable": true,
         "visible": true,
         "type": "password",
-        "name": "password",
-        "description": "Password used to access the Group IB server to which you will connect and perform the automated operations."
+        "name": "api_key",
+        "description": "API key used to access the Group IB server to which you will connect and perform the automated operations."
       },
       {
         "title": "Verify SSL",

--- a/group-ib-threat-intelligence-attribution-feed/operations.py
+++ b/group-ib-threat-intelligence-attribution-feed/operations.py
@@ -1,7 +1,7 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2024   Fortinet Inc
+Copyright (c) 2025   Fortinet Inc
 Copyright end
 """
 

--- a/group-ib-threat-intelligence-attribution-feed/operations.py
+++ b/group-ib-threat-intelligence-attribution-feed/operations.py
@@ -24,7 +24,7 @@ class GroupIB():
         else:
             self.server_url = 'https://{0}'.format(self.server_url.strip('/')) + '/api/v2/'
         self.username = config.get('username')
-        self.password = config.get('password')
+        self.api_key = config.get('api_key')
         self.verify_ssl = config.get('verify_ssl')
 
     def make_api_call(self, method='GET', endpoint=None, params=None, data=None,
@@ -37,7 +37,7 @@ class GroupIB():
         logger.info('Request URL {0}'.format(url))
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
         try:
-            response = requests.request(method=method, url=url, auth=(self.username, self.password), params=params,
+            response = requests.request(method=method, url=url, auth=(self.username, self.api_key), params=params,
                                         data=data, json=json,
                                         headers=headers,
                                         verify=self.verify_ssl)

--- a/group-ib-threat-intelligence-attribution-feed/playbooks/playbooks.json
+++ b/group-ib-threat-intelligence-attribution-feed/playbooks/playbooks.json
@@ -3,7 +3,7 @@
   "data": [
     {
       "@type": "WorkflowCollection",
-      "name": "Sample - Group IB Threat Intelligence & Attribution Feed - 1.1.0",
+      "name": "Sample - Group IB Threat Intelligence & Attribution Feed - 1.2.0",
       "description": "Sample playbooks for \"Group IB Threat Intelligence & Attribution Feed\" connector. If you are planning to use any of the sample playbooks in your environment, ensure that you clone those playbooks and move them to a different collection, since the sample playbook collection gets deleted during connector upgrade and delete.",
       "visible": true,
       "uuid": "aab30456-d319-44a3-af1e-07f877647c7d",
@@ -68,7 +68,7 @@
                   "limit": 50,
                   "collection": "attacks/ddos"
                 },
-                "version": "1.1.0",
+                "version": "1.2.0",
                 "connector": "group-ib-threat-intelligence-attribution-feed",
                 "operation": "get_indicators",
                 "operationTitle": "Get Indicators",
@@ -164,7 +164,7 @@
                   "q": "1.1.1.1",
                   "limit": 5
                 },
-                "version": "1.1.0",
+                "version": "1.2.0",
                 "connector": "group-ib-threat-intelligence-attribution-feed",
                 "operation": "search_indicator",
                 "operationTitle": "Search Indicator",
@@ -301,7 +301,7 @@
                   "q": "{{vars.indicator_value}}",
                   "limit": 5
                 },
-                "version": "1.1.0",
+                "version": "1.2.0",
                 "connector": "group-ib-threat-intelligence-attribution-feed",
                 "operation": "search_indicator",
                 "operationTitle": "Search Indicator",

--- a/group-ib-threat-intelligence-attribution-feed/release-notes.md
+++ b/group-ib-threat-intelligence-attribution-feed/release-notes.md
@@ -1,5 +1,4 @@
-#### What's Improved
+#### What's Fixed
 
-- The indicator enrichment playbook Domain / IP / URL > GroupIB Threat Intelligence > Enrichment includes enriching file hashes, domains, IPs, and URLs, Emails via GroupIB Threat Intelligence. Optionally, it retrieves the indicator reputation and calculates the reputation summary from the Group IB Threat Intelligence.
-- Added the following new operations and playbooks:
-  - Search Indicator
+- The configuration parameter `password` has been replaced with `API Key` 
+- > The authentication method using username and password is deprecated and no longer supported.


### PR DESCRIPTION
#### What's Fixed

- The configuration parameter `password` has been replaced with `API Key` 
- > The authentication method using username and password is deprecated and no longer supported.

Mantis: https://mantis.fortinet.com/bug_view_page.php?bug_id=1173682